### PR TITLE
Remove dog recruit

### DIFF
--- a/Assets/Scripts/Engine/Components/Creature/Liberal.cs
+++ b/Assets/Scripts/Engine/Components/Creature/Liberal.cs
@@ -1847,8 +1847,8 @@ namespace LCS.Engine.Components.Creature
             {
                 if (creature == null) continue;
 
-                // Dogs aren't that useful as sleeper agents.
-                if (creature.type.Equals("GUARDDOG")) continue;
+                // We might be liberal, but even so we only need humans.
+                if (creature.getComponent<Body>().getSpecies().type != "HUMAN") continue;
 
                 //Liberals are easier to recruit than non-liberals
                 if (creature.getComponent<CreatureInfo>().alignment != Alignment.LIBERAL &&

--- a/Assets/Scripts/Engine/Components/Creature/Liberal.cs
+++ b/Assets/Scripts/Engine/Components/Creature/Liberal.cs
@@ -1846,6 +1846,10 @@ namespace LCS.Engine.Components.Creature
             foreach (Entity creature in recruitOptions)
             {
                 if (creature == null) continue;
+
+                // Dogs aren't that useful as sleeper agents.
+                if (creature.type.Equals("GUARDDOG")) continue;
+
                 //Liberals are easier to recruit than non-liberals
                 if (creature.getComponent<CreatureInfo>().alignment != Alignment.LIBERAL &&
                     MasterController.GetMC().LCSRandom(5) != 0)


### PR DESCRIPTION
I noticed that when you let a sleeper recruit further liberals sometimes there will be guard dogs which are being recruited.

So I added a check if the target creature is Human.