### PR TITLE
Fix wrong value calculation when selling stolen cars

### DIFF
--- a/Assets/Scripts/Engine/Components/Location/Shop.cs
+++ b/Assets/Scripts/Engine/Components/Location/Shop.cs
@@ -110,10 +110,11 @@ namespace LCS.Engine.Components.Location
                 }
                 else
                 {
-                    value += item.getComponent<Loot>().getFenceValue();
+                    int itemValue = item.getComponent<Loot>().getFenceValue();
                     //Stolen cars are worth SIGNIFICANTLY less
                     if (item.hasComponent<Vehicle>() && item.getComponent<Vehicle>().heat > 0)
-                        value /= 10;
+                        itemValue /= 10;
+                    value += itemValue;
                 }                
             }
 


### PR DESCRIPTION
Fix for issue #5. Instead of adding the current item value to the total and then dividing the total cart value by 10 if the car is stolen, I store the current item value in `itemValue`, divide that by 10 if it's a stolen car, and finally add `itemValue` to the total value of the cart.